### PR TITLE
chore: update oodle-safe to 0.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,5 +34,5 @@ arctree = "0.1.0"
 derivative = "2.2.0"
 log = "0.4.17"
 lz4_flex = "0.9.5"
-oodle-safe = "0.1"
+oodle-safe = "0.2"
 zerocopy = { version = "0.7.32", features = ["derive"] }


### PR DESCRIPTION
This allows lotus-lib to build on windows